### PR TITLE
Update dependencies

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -7,7 +7,6 @@ const extras = require('./extras.js');
 
 var S = require('string');
 const removeMd = require('remove-markdown');
-var parseXml = require('xml2js').parseString;
 
 var request = require('request');
 

--- a/package.json
+++ b/package.json
@@ -5,14 +5,10 @@
   "main": "bot.js",
   "dependencies": {
     "apiai": "^4.0.3",
-    "discord.js": "^11.3.2",
-    "erlpack": "^0.1.0",
-    "forever": "^0.15.3",
-    "remove-markdown": "^0.2.2",
-    "request": "^2.83.0",
-    "string": "^3.3.3",
-    "uws": "^0.14.5",
-    "xml2js": "^0.4.19"
+    "discord.js": "^11.5.1",
+    "remove-markdown": "^0.3.0",
+    "request": "^2.88.0",
+    "string": "^3.3.3"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
Note: Removes `xml2js`, `erlpack`, `forever`, `uws`
1. `xml2js` - Unused
2. `erlpack` and  `uws` - Voice only
3.  `forever` - Unused